### PR TITLE
chore: add skipLibCheck to bypass @types/node ↔ lib.dom AbortSignal collision

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
## Summary

`yarn tsc --noEmit` was failing with one error in `node_modules/@types/node/globals.d.ts:72`: TS2403 — `AbortSignal` redeclared without the static `abort()` / `timeout()` members that `lib.dom` now ships. SDK source itself is clean; the failure is purely from `@types/node` ↔ `lib.dom` global declaration merging.

Setting `skipLibCheck: true` in `tsconfig.json` skips type-checking of `.d.ts` files only. Strict mode flags (`strict`, `noImplicitAny`, `strictNullChecks`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`) remain on for SDK source.

## Test plan

- [x] `yarn tsc --noEmit` exits 0 after change
- [ ] `yarn build` (typechain + microbundle) succeeds
- [ ] Downstream consumer (`qidao` linked via `portal:`) typechecks against the rebuilt SDK